### PR TITLE
feat: add backup tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ To generate an API key: Dispatcharr UI → **System → Users** → edit your us
 | **System** | `get_core_settings`, `list_stream_profiles`, `get_system_events`, `list_integrations`, `list_stream_delivery_logs` |
 | **DVR** | `list_recordings`, `get_recording` |
 | **HDHomeRun** | `list_hdhr_devices` |
+| **Backups** | `create_backup`, `list_backups`, `get_backup_status`, `download_backup`, `restore_backup`, `delete_backup`, `get_backup_schedule`, `update_backup_schedule` |
 
 ## Requirements
 

--- a/dispatcharr_mcp/server.py
+++ b/dispatcharr_mcp/server.py
@@ -7,6 +7,7 @@ Tools are grouped by domain:
   • EPG            — EPG sources and programme data
   • M3U Accounts   — manage M3U provider accounts
   • VOD            — movies, series, episodes
+  • Backups        — create, list, download, restore, schedule backups
   • System         — settings, stream profiles, system events
 """
 
@@ -596,6 +597,94 @@ async def get_recording(recording_id: int) -> dict:
 async def list_hdhr_devices() -> list:
     """List all configured HDHomeRun virtual tuner devices."""
     return await _client().get("/api/hdhr/devices/")
+
+
+# ---------------------------------------------------------------------------
+# BACKUPS
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def create_backup() -> dict:
+    """Trigger a new backup of the Dispatcharr database and configuration.
+
+    Returns a task object with a `task_id` that can be polled with
+    `get_backup_status` to track progress.
+    """
+    return await _client().post("/api/backups/create/")
+
+
+@mcp.tool()
+async def list_backups() -> list:
+    """List all available backups.
+
+    Returns filename, size, creation date, and other metadata for each backup.
+    """
+    return await _client().get("/api/backups/")
+
+
+@mcp.tool()
+async def get_backup_status(task_id: str) -> dict:
+    """Check the progress of a backup or restore task.
+
+    Pass the `task_id` returned by `create_backup` or `restore_backup`.
+    Returns status (pending/running/completed/failed) and progress details.
+    """
+    return await _client().get(f"/api/backups/status/{task_id}/")
+
+
+@mcp.tool()
+async def download_backup(filename: str) -> dict:
+    """Get a download URL for a backup file.
+
+    Since MCP tools cannot return binary files, this returns a dict containing
+    the download URL with an authenticated token. Open the URL in a browser
+    or use curl/wget to download the backup archive.
+    """
+    token_data = await _client().get(
+        f"/api/backups/{filename}/download-token/"
+    )
+    token = token_data.get("token", "") if isinstance(token_data, dict) else ""
+    base = _client()._base
+    return {
+        "url": f"{base}/api/backups/{filename}/download/?token={token}",
+        "filename": filename,
+    }
+
+
+@mcp.tool()
+async def restore_backup(filename: str) -> dict:
+    """Restore Dispatcharr from a specific backup file.
+
+    WARNING: This overwrites the current database and configuration.
+    Returns a task object — use `get_backup_status` to track progress.
+    """
+    return await _client().post(f"/api/backups/{filename}/restore/")
+
+
+@mcp.tool()
+async def delete_backup(filename: str) -> dict:
+    """Delete a backup file by its filename."""
+    return await _client().delete(f"/api/backups/{filename}/delete/")
+
+
+@mcp.tool()
+async def get_backup_schedule() -> dict:
+    """Get the current backup schedule configuration.
+
+    Returns enabled status, interval, retention policy, and other settings.
+    """
+    return await _client().get("/api/backups/schedule/")
+
+
+@mcp.tool()
+async def update_backup_schedule(fields: dict) -> dict:
+    """Update the backup schedule configuration.
+
+    Pass any subset of schedule fields as `fields`
+    (e.g. ``{"enabled": true, "interval_hours": 24, "retain_count": 7}``).
+    """
+    return await _client().put("/api/backups/schedule/update/", data=fields)
 
 
 # ---------------------------------------------------------------------------

--- a/dispatcharr_mcp/server.py
+++ b/dispatcharr_mcp/server.py
@@ -633,15 +633,16 @@ async def get_backup_status(
 
     Pass the `task_id` returned by `create_backup` or `restore_backup`.
 
-    By default, polls until the task reaches a terminal state (completed/failed)
-    or the timeout is reached. Set `wait=False` for a single status check.
+    By default, polls every 2 seconds until the task reaches a terminal state
+    (completed/failed) or the timeout is reached. Set `wait=False` for a
+    single instant status check.
     Returns status, progress details, and result when complete.
     """
     import asyncio
 
     terminal = {"completed", "failed", "cancelled", "success", "error"}
     elapsed = 0
-    interval = 3
+    interval = 2
 
     while True:
         result = await _client().get(f"/api/backups/status/{task_id}/")
@@ -705,13 +706,43 @@ async def get_backup_schedule() -> dict:
 
 
 @mcp.tool()
-async def update_backup_schedule(fields: dict) -> dict:
+async def update_backup_schedule(
+    enabled: bool | None = None,
+    frequency: str | None = None,
+    time: str | None = None,
+    day_of_week: int | None = None,
+    retention_count: int | None = None,
+    cron_expression: str | None = None,
+) -> dict:
     """Update the backup schedule configuration.
 
-    Pass any subset of schedule fields as `fields`
-    (e.g. ``{"enabled": true, "interval_hours": 24, "retain_count": 7}``).
+    All parameters are optional — only provided fields are changed.
+
+    Args:
+        enabled: Enable or disable scheduled backups.
+        frequency: How often to run backups. Must be ``"daily"`` or ``"weekly"``.
+        time: Time of day to run the backup, in ``"HH:MM"`` format (24h, e.g. ``"03:00"``).
+        day_of_week: Day of week for weekly backups. 0=Sunday, 1=Monday, ..., 6=Saturday.
+            Ignored when frequency is ``"daily"``.
+        retention_count: Number of backups to keep. Older backups are deleted automatically.
+            Set to 0 to keep all backups.
+        cron_expression: Advanced — a custom cron expression (e.g. ``"0 3 * * *"``).
+            Overrides frequency/time/day_of_week when set. Set to empty string to
+            go back to simple frequency mode.
     """
-    return await _client().put("/api/backups/schedule/update/", data=fields)
+    return await _client().put(
+        "/api/backups/schedule/update/",
+        data=_clean(
+            {
+                "enabled": enabled,
+                "frequency": frequency,
+                "time": time,
+                "day_of_week": day_of_week,
+                "retention_count": retention_count,
+                "cron_expression": cron_expression,
+            }
+        ),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/dispatcharr_mcp/server.py
+++ b/dispatcharr_mcp/server.py
@@ -700,49 +700,33 @@ async def delete_backup(filename: str) -> dict:
 async def get_backup_schedule() -> dict:
     """Get the current backup schedule configuration.
 
-    Returns enabled status, interval, retention policy, and other settings.
+    Returns: enabled (bool), frequency (str: "daily"/"weekly"), time (str: "HH:MM"),
+    day_of_week (int: 0-6), retention_count (int), cron_expression (str).
     """
     return await _client().get("/api/backups/schedule/")
 
 
 @mcp.tool()
-async def update_backup_schedule(
-    enabled: bool | None = None,
-    frequency: str | None = None,
-    time: str | None = None,
-    day_of_week: int | None = None,
-    retention_count: int | None = None,
-    cron_expression: str | None = None,
-) -> dict:
+async def update_backup_schedule(fields: dict) -> dict:
     """Update the backup schedule configuration.
 
-    All parameters are optional — only provided fields are changed.
+    Pass any subset of schedule fields as `fields`. Only provided fields are changed.
 
-    Args:
-        enabled: Enable or disable scheduled backups.
-        frequency: How often to run backups. Must be ``"daily"`` or ``"weekly"``.
-        time: Time of day to run the backup, in ``"HH:MM"`` format (24h, e.g. ``"03:00"``).
-        day_of_week: Day of week for weekly backups. 0=Sunday, 1=Monday, ..., 6=Saturday.
+    Accepted fields:
+        enabled (bool): Enable or disable scheduled backups.
+        frequency (str): How often to run. Must be ``"daily"`` or ``"weekly"``.
+        time (str): Time of day in ``"HH:MM"`` format, 24-hour (e.g. ``"03:00"``).
+        day_of_week (int): Day of week for weekly frequency. 0=Sunday through 6=Saturday.
             Ignored when frequency is ``"daily"``.
-        retention_count: Number of backups to keep. Older backups are deleted automatically.
-            Set to 0 to keep all backups.
-        cron_expression: Advanced — a custom cron expression (e.g. ``"0 3 * * *"``).
-            Overrides frequency/time/day_of_week when set. Set to empty string to
-            go back to simple frequency mode.
+        retention_count (int): Number of backups to keep. Older ones are auto-deleted.
+            Set to 0 to keep all.
+        cron_expression (str): Custom cron expression (e.g. ``"0 3 * * *"``).
+            Overrides frequency/time/day_of_week when set. Set to ``""`` to go
+            back to simple frequency mode.
+
+    Example: ``{"enabled": true, "frequency": "daily", "time": "03:00", "retention_count": 5}``
     """
-    return await _client().put(
-        "/api/backups/schedule/update/",
-        data=_clean(
-            {
-                "enabled": enabled,
-                "frequency": frequency,
-                "time": time,
-                "day_of_week": day_of_week,
-                "retention_count": retention_count,
-                "cron_expression": cron_expression,
-            }
-        ),
-    )
+    return await _client().put("/api/backups/schedule/update/", data=fields)
 
 
 # ---------------------------------------------------------------------------

--- a/dispatcharr_mcp/server.py
+++ b/dispatcharr_mcp/server.py
@@ -624,13 +624,40 @@ async def list_backups() -> list:
 
 
 @mcp.tool()
-async def get_backup_status(task_id: str) -> dict:
+async def get_backup_status(
+    task_id: str,
+    wait: bool = True,
+    timeout: int = 120,
+) -> dict:
     """Check the progress of a backup or restore task.
 
     Pass the `task_id` returned by `create_backup` or `restore_backup`.
-    Returns status (pending/running/completed/failed) and progress details.
+
+    By default, polls until the task reaches a terminal state (completed/failed)
+    or the timeout is reached. Set `wait=False` for a single status check.
+    Returns status, progress details, and result when complete.
     """
-    return await _client().get(f"/api/backups/status/{task_id}/")
+    import asyncio
+
+    terminal = {"completed", "failed", "cancelled", "success", "error"}
+    elapsed = 0
+    interval = 3
+
+    while True:
+        result = await _client().get(f"/api/backups/status/{task_id}/")
+        if not wait:
+            return result
+        status = result.get("status", "") if isinstance(result, dict) else ""
+        if status.lower() in terminal:
+            return result
+        if elapsed >= timeout:
+            result["_timed_out"] = True
+            result["_message"] = (
+                f"Timeout after {timeout}s. Call again with the same task_id to continue waiting."
+            )
+            return result
+        await asyncio.sleep(interval)
+        elapsed += interval
 
 
 @mcp.tool()


### PR DESCRIPTION
## Summary

Add 8 MCP tools for the Dispatcharr backup API, covering backup create, list, download, restore, delete, and schedule management.

Closes #1

## Tools Added

| Tool | API Endpoint | Description |
|------|-------------|-------------|
| `create_backup` | `POST /api/backups/create/` | Trigger a new backup |
| `list_backups` | `GET /api/backups/` | List all backups |
| `get_backup_status` | `GET /api/backups/status/{task_id}/` | Check backup task progress |
| `download_backup` | `GET /api/backups/{filename}/download-token/` | Returns download URL with auth token |
| `restore_backup` | `POST /api/backups/{filename}/restore/` | Restore from a backup |
| `delete_backup` | `DELETE /api/backups/{filename}/delete/` | Delete a backup |
| `get_backup_schedule` | `GET /api/backups/schedule/` | Get backup schedule config |
| `update_backup_schedule` | `PUT /api/backups/schedule/update/` | Update schedule settings |

## Design Notes

- `download_backup` uses the two-step download-token flow. Since MCP tools cannot return binary data, it returns a dict with the full download URL (base URL + filename + auth token) that the user can open in a browser or curl.
- All tools follow the existing pattern: `@mcp.tool()` decorator, `_client()` for API calls, `_clean()` for param stripping, descriptive docstrings.
- `update_backup_schedule` accepts a `fields: dict` for partial updates, matching the pattern used by `update_channel` and `update_epg_source`.

## Testing

- All 55 tools load successfully (47 existing + 8 new)
- Import verified: `from dispatcharr_mcp.server import mcp`