### PR TITLE
fix: bulk_delete_channels sends channel_ids as JSON body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to dispatcharr-mcp are documented here.
 
 ---
 
+## [0.3.1] - 2026-04-28
+
+### Fixed
+
+- `bulk_delete_channels` now sends `channel_ids` as JSON body instead of query params. The Dispatcharr API expects `{"channel_ids": [...]}` in the request body — query params were silently ignored, deleting nothing.
+- `DispatcharrClient.delete()` now accepts an optional `data` parameter for sending JSON body with DELETE requests.
+
+---
+
 ## [0.2.0] - 2026-04-22
 
 ### Added

--- a/dispatcharr_mcp/client.py
+++ b/dispatcharr_mcp/client.py
@@ -117,5 +117,5 @@ class DispatcharrClient:
     async def patch(self, path: str, data: dict) -> Any:
         return await self._request("PATCH", path, json=data)
 
-    async def delete(self, path: str, params: dict | None = None) -> dict:
-        return await self._request("DELETE", path, params=params)
+    async def delete(self, path: str, params: dict | None = None, data: dict | None = None) -> dict:
+        return await self._request("DELETE", path, params=params, json=data)

--- a/dispatcharr_mcp/server.py
+++ b/dispatcharr_mcp/server.py
@@ -121,7 +121,7 @@ async def bulk_delete_channels(channel_ids: list[int]) -> dict:
     """
     return await _client().delete(
         "/api/channels/channels/bulk-delete/",
-        params={"ids": ",".join(str(i) for i in channel_ids)},
+        data={"channel_ids": channel_ids},
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dispatcharr-mcp"
-version = "0.3.0"
+version = "0.3.1"
 description = "MCP server for Dispatcharr IPTV stream management"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Fix `bulk_delete_channels` to send `channel_ids` as JSON body instead of query params — the Dispatcharr API expects `{"channel_ids": [...]}` in the request body
- Add `data` parameter support to `DispatcharrClient.delete()` for sending JSON body with DELETE requests

## Root Cause
The Dispatcharr backend reads from `request.data.get("channel_ids", [])` (JSON body), but the MCP tool was sending IDs as URL query params which were silently ignored, resulting in zero deletions despite a successful response.

## Testing
- `bulk_delete_channels` with 10 IDs → returned `{}` but channels still existed
- `delete_channel` with single ID → worked correctly (404 on subsequent get)
- After fix: tool sends `{"channel_ids": [...]}` as JSON body matching the API contract

Fixes #13